### PR TITLE
Revert back to old latest

### DIFF
--- a/src/controllers/mysql/queries/queries.ts
+++ b/src/controllers/mysql/queries/queries.ts
@@ -224,7 +224,7 @@ export function countComment(postId: number){
 export function latestDigestedPostNumber() {
   return new Promise((resolve, reject) => {
     
-      connection.query('SELECT MAX(helge_id) as hanesst_id FROM (SELECT helge_id FROM post UNION SELECT helge_id FROM comment) as table3;', (error, results, fields) => {
+      connection.query('SELECT * FROM post ORDER BY helge_id DESC LIMIT 1;', (error, results, fields) => {
         if(error){
           reject(error)
         }


### PR DESCRIPTION
The "new" latest query was way too heavy and pretty much brought the backend to a halt.
To fix this, the /latest has been reverted back to its old query that, while a bit incorrect, is stable.